### PR TITLE
Add Vagrant file with CouchDB 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ testem.log
 #System Files
 .DS_Store
 Thumbs.db
+
+/.vagrant/
+*-cloudimg-console.log

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,14 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/xenial64"
+
+  config.vm.network "forwarded_port", guest: 5984, host: 5984
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "512"
+  end
+
+  config.vm.provision 'shell', path: 'script/vagrant-provision.sh'
+end

--- a/script/vagrant-provision.sh
+++ b/script/vagrant-provision.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+
+v="2.0.0"
+download_url="http://apache.mirror.iphh.net/couchdb/source/2.0.0/apache-couchdb-2.0.0.tar.gz"
+
+apt-get update
+apt-get --no-install-recommends -y install build-essential \
+	pkg-config erlang libicu-dev libmozjs185-dev \
+	libcurl4-openssl-dev help2man python-sphinx
+
+mkdir -p /opt/src
+curl -s $download_url | tar -C /opt/src -xzf -
+
+(cd /opt/src/apache-couchdb-${v} && ./configure -u root -c)
+(cd /opt/src/apache-couchdb-${v} && make release)
+(cd /opt/src/apache-couchdb-${v} && cp -R rel/couchdb /opt)
+
+sed -i -e 's,;bind_address = 127.0.0.1,bind_address = 0.0.0.0,g' /opt/couchdb/etc/local.ini
+
+cat <<__SYSTEMD > /etc/systemd/system/couchdb.service
+[Unit]
+Description=CouchDB Service
+After=network.target
+
+[Service]
+User=root
+ExecStart=/opt/couchdb/bin/couchdb
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+__SYSTEMD
+
+systemctl daemon-reload
+systemctl enable couchdb.service
+systemctl start couchdb.service


### PR DESCRIPTION
The provision script downloads and compiles CouchDB because it's not available as a binary package at the moment.