### PR TITLE
Cleanup ng and electron build process

### DIFF
--- a/angular-cli.json
+++ b/angular-cli.json
@@ -9,7 +9,12 @@
       "outDir": "dist",
       "assets": [
         "assets",
-        "favicon.ico"
+        "components",
+        "css",
+        "favicon.ico",
+        "fonts",
+        "index.js",
+        "js"
       ],
       "index": "index.html",
       "main": "main.ts",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "sar-client",
   "version": "0.0.0",
   "license": "MIT",
+  "main": "dist/index.js",
   "angular-cli": {},
   "scripts": {
     "ng": "ng",
@@ -10,8 +11,10 @@
     "test": "ng test",
     "pree2e": "webdriver-manager update --standalone false --gecko false",
     "e2e": "protractor",
-    "build-electron": "ng build && cp -R src/ dist/",
-    "electron": "npm run build-electron && electron dist/src/electron"
+    "ng:build": "ng build",
+    "ng:build:watch": "ng build --watch",
+    "electron": "run-s ng:build electron:start",
+    "electron:start": "electron ."
   },
   "private": true,
   "dependencies": {
@@ -44,6 +47,7 @@
     "karma-cli": "^1.0.1",
     "karma-jasmine": "^1.0.2",
     "karma-remap-istanbul": "^0.2.1",
+    "npm-run-all": "^4.0.1",
     "protractor": "~4.0.13",
     "ts-node": "1.2.1",
     "tslint": "^4.3.0",

--- a/src/electron/package.json
+++ b/src/electron/package.json
@@ -1,5 +1,0 @@
-{
-  "name"    : "angular-electron",
-  "version" : "0.1.0",
-  "main"    : "electron.js"
-}

--- a/src/index.html
+++ b/src/index.html
@@ -36,7 +36,7 @@
     <script src="components/jquery/dist/jquery.min.js" type="text/javascript"></script>
 
     <script src="js/leaflet.js"></script>
-    <script type="text/javascript" src="../inline.bundle.js"></script>
-    <script type="text/javascript" src="../vendor.bundle.js"></script>
-    <script type="text/javascript" src="../main.bundle.js"></script>
+    <script type="text/javascript" src="inline.bundle.js"></script>
+    <script type="text/javascript" src="vendor.bundle.js"></script>
+    <script type="text/javascript" src="main.bundle.js"></script>
 </body></html>

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ function createWindow () {
   win = new BrowserWindow({width: 800, height: 600})
 
   // and load the index.html of the app.
-  win.loadURL(`file://${__dirname}/../index.html`)
+  win.loadURL(`file://${__dirname}/index.html`)
 
   // Open the DevTools.
   win.webContents.openDevTools()


### PR DESCRIPTION
While working on the packaging for the electron app, I noticed that we manually copy the complete `src/` folder into `dist/` to provide some assets. I changed the angular-cli config to copy those files so we don't have to run two commands. Running `ng build` is enough now.

I also moved the electron entry point from `src/electron/electron.js` to `src/index.js` and removed the unnecessary `src/electron/package.json` file. The electron app can now be started via `electron .` in the root directory.

In addition, I added a `ng:build:watch` script which can be used instead of `ng:build` to continuously watch for changes and recompile only the changed parts. The first run is about 9 sec on my machine, after that it only takes around 800 ms when changing some app code.
  
## Summary

- Let angular-cli copy all assets to `dist/` instead of using `cp -R`
- Move electron entry point to `src/index.js` and remove now unused `src/electron` directory
- Use npm-run-all and rename npm run scripts (`build-electron` => `ng:build`)
- Add `ng:build:watch` script