### PR TITLE
Use electron-builder to build artifacts for Windows, macOS and Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # compiled output
 /dist
+/dist-builder
 /tmp
 
 # dependencies

--- a/angular-cli.json
+++ b/angular-cli.json
@@ -9,7 +9,12 @@
       "outDir": "dist",
       "assets": [
         "assets",
-        "favicon.ico"
+        "components",
+        "css",
+        "favicon.ico",
+        "fonts",
+        "index.js",
+        "js"
       ],
       "index": "index.html",
       "main": "main.ts",

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,0 +1,38 @@
+appId: org.sar-app.client
+productName: SAR-Client
+
+asar: true
+
+directories:
+  output: dist-builder/
+
+dmg:
+  contents:
+    - type: link
+      path: /Applications
+      x: 410
+      y: 150
+    - type: file
+      x: 130
+      y: 150
+
+files:
+  - package.json
+  - dist/**/*
+
+linux:
+  category: Network
+  packageCategory: Network
+  description: SAR Client application
+  target:
+    - AppImage
+
+mac:
+  target: dmg
+  category: public.app-category.productivity
+
+nsis:
+  artifactName: ${name}-${version}.${ext}
+
+win:
+  target: nsis

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "sar-client",
   "version": "0.0.0",
   "license": "MIT",
+  "main": "dist/index.js",
   "angular-cli": {},
   "scripts": {
     "ng": "ng",
@@ -10,8 +11,10 @@
     "test": "ng test",
     "pree2e": "webdriver-manager update --standalone false --gecko false",
     "e2e": "protractor",
-    "build-electron": "ng build && cp -R src/ dist/",
-    "electron": "npm run build-electron && electron dist/src/electron"
+    "ng:build": "ng build",
+    "ng:build:watch": "ng build --watch",
+    "electron": "run-s ng:build electron:start",
+    "electron:start": "electron ."
   },
   "private": true,
   "dependencies": {
@@ -44,6 +47,7 @@
     "karma-cli": "^1.0.1",
     "karma-jasmine": "^1.0.2",
     "karma-remap-istanbul": "^0.2.1",
+    "npm-run-all": "^4.0.1",
     "protractor": "~4.0.13",
     "ts-node": "1.2.1",
     "tslint": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,10 @@
 {
   "name": "sar-client",
+  "description": "SAR-Client App",
+  "author": {
+    "name": "Sea Watch",
+    "email": "nic@sea-watch.org"
+  },
   "version": "0.0.0",
   "license": "MIT",
   "main": "dist/index.js",
@@ -14,7 +19,14 @@
     "ng:build": "ng build",
     "ng:build:watch": "ng build --watch",
     "electron": "run-s ng:build electron:start",
-    "electron:start": "electron ."
+    "electron:start": "electron .",
+    "pack": "run-s ng:build pack:build:win pack:build:linux",
+    "pack:mac": "run-s ng:build pack:build:mac",
+    "pack:win": "run-s ng:build pack:build:win",
+    "pack:linux": "run-s ng:build pack:build:linux",
+    "pack:build:mac": "build -c electron-builder.yml --mac --x64",
+    "pack:build:win": "build -c electron-builder.yml --win --ia32 --x64",
+    "pack:build:linux": "build -c electron-builder.yml --linux --x64"
   },
   "private": true,
   "dependencies": {
@@ -40,6 +52,7 @@
     "angular-cli": "1.0.0-beta.25.5",
     "codelyzer": "~2.0.0-beta.1",
     "electron": "^1.4.15",
+    "electron-builder": "13.8.0",
     "jasmine-core": "2.5.2",
     "jasmine-spec-reporter": "2.5.0",
     "karma": "1.2.0",

--- a/src/electron/package.json
+++ b/src/electron/package.json
@@ -1,5 +1,0 @@
-{
-  "name"    : "angular-electron",
-  "version" : "0.1.0",
-  "main"    : "electron.js"
-}

--- a/src/index.html
+++ b/src/index.html
@@ -36,7 +36,7 @@
     <script src="components/jquery/dist/jquery.min.js" type="text/javascript"></script>
 
     <script src="js/leaflet.js"></script>
-    <script type="text/javascript" src="../inline.bundle.js"></script>
-    <script type="text/javascript" src="../vendor.bundle.js"></script>
-    <script type="text/javascript" src="../main.bundle.js"></script>
+    <script type="text/javascript" src="inline.bundle.js"></script>
+    <script type="text/javascript" src="vendor.bundle.js"></script>
+    <script type="text/javascript" src="main.bundle.js"></script>
 </body></html>

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ function createWindow () {
   win = new BrowserWindow({width: 800, height: 600})
 
   // and load the index.html of the app.
-  win.loadURL(`file://${__dirname}/../index.html`)
+  win.loadURL(`file://${__dirname}/index.html`)
 
   // Open the DevTools.
   win.webContents.openDevTools()


### PR DESCRIPTION
This adds the basic infrastructure to build artifacts for Windows, macOS and Linux via npm.

Refs #3 

**ATTENTION:** This includes the commits from #27 and should only be merged after #27 has been merged! (needs to be rebased before that)