### PR TITLE
Switch windows artifact to "portable" and disable x64 build

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -35,4 +35,4 @@ nsis:
   artifactName: ${name}-${version}.${ext}
 
 win:
-  target: nsis
+  target: portable

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "pack:win": "run-s ng:build:noprogress pack:build:win",
     "pack:linux": "run-s ng:build:noprogress pack:build:linux",
     "pack:build:mac": "build -c electron-builder.yml --mac --x64",
-    "pack:build:win": "build -c electron-builder.yml --win --ia32 --x64",
+    "pack:build:win": "build -c electron-builder.yml --win --ia32",
     "pack:build:linux": "build -c electron-builder.yml --linux --x64"
   },
   "private": true,
@@ -58,7 +58,7 @@
     "@types/node": "^6.0.42",
     "codelyzer": "~2.0.0-beta.1",
     "electron": "^1.4.15",
-    "electron-builder": "^15.3.0",
+    "electron-builder": "^16.3.0",
     "jasmine-core": "^2.5.2",
     "jasmine-spec-reporter": "^3.2.0",
     "karma": "^1.5.0",


### PR DESCRIPTION
Using a portable artifact does not require the app to be installed on windows. That means a user can just download the .exe file and run it with a double klick.

Also update electron-builder to the latest version to allow ia32 only build for windows.