### PR TITLE
Generate the config/version.js from a template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ Thumbs.db
 
 # Map tiles
 /src/MapQuest/
+
+# Generated config file
+/src/config/version.js

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
     "pretest": "run-s fmt",
     "pree2e": "webdriver-manager update --standalone false --gecko false",
     "e2e": "protractor",
-    "preng:build": "run-s fmt",
+    "preng:build": "run-s fmt generate:all",
     "postng:build": "run-s maptiles:clean maptiles:extract",
+    "preng:build:noprogress": "run-s generate:all",
     "postng:build:noprogress": "run-s maptiles:clean maptiles:extract",
     "ng:build": "ng build",
     "ng:build:watch": "ng build --watch",
@@ -35,7 +36,9 @@
     "pack:build:win": "build -c electron-builder.yml --win --ia32",
     "pack:build:linux": "build -c electron-builder.yml --linux --x64",
     "maptiles:clean": "rimraf dist/MapQuest",
-    "maptiles:extract": "extract-zip data/map-tiles.zip dist/"
+    "maptiles:extract": "extract-zip data/map-tiles.zip dist/",
+    "generate:all": "run-s generate:version",
+    "generate:version": "node script/generate-version.js"
   },
   "private": true,
   "dependencies": {
@@ -74,6 +77,7 @@
     "karma-jasmine": "^1.0.2",
     "karma-phantomjs-launcher": "^1.0.2",
     "karma-remap-istanbul": "^0.6.0",
+    "mustache": "^2.3.0",
     "npm-run-all": "^4.0.1",
     "protractor": "~5.1.1",
     "rimraf": "^2.6.1",

--- a/script/generate-version.js
+++ b/script/generate-version.js
@@ -1,0 +1,23 @@
+/**
+ * Script to generate the src/config/version.js file from a template.
+ */
+const Mustache = require('mustache');
+const { execSync } = require('child_process');
+const { readFileSync, writeFileSync } = require('fs');
+const path = require('path');
+const nodePackage = require(path.resolve(__dirname, '..', 'package.json'));
+
+const configDir = path.resolve(__dirname, '..', 'src', 'config');
+const templateFile = path.resolve(configDir, 'version.js.mustache');
+const outputFile = path.resolve(configDir, 'version.js');
+
+const view = {
+  version: nodePackage.version,
+  gitRevision: () => execSync('git rev-parse --short HEAD').toString().trim(),
+};
+
+const template = readFileSync(templateFile).toString();
+
+const output = Mustache.render(template, view);
+
+writeFileSync(outputFile, output);

--- a/src/config/version.js
+++ b/src/config/version.js
@@ -1,3 +1,0 @@
-module.exports = {
-    version: 'v0.0.1-alpha.2',
-}

--- a/src/config/version.js.mustache
+++ b/src/config/version.js.mustache
@@ -1,0 +1,4 @@
+module.exports = {
+  version: "v{{version}}",
+  gitRevision: "{{gitRevision}}"
+}


### PR DESCRIPTION
Avoids manual maintenance of the version number.

Fixes #78