### PR TITLE
Fix packaged artifact by including dependencies

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -19,6 +19,10 @@ dmg:
 files:
   - package.json
   - dist/**/*
+  # Needed to make sure we have all runtime dependencies.
+  # The devDependencies will NOT be packaged, electron-builder takes
+  # care of that.
+  - node_modules
 
 linux:
   category: Network

--- a/package.json
+++ b/package.json
@@ -42,31 +42,25 @@
   },
   "private": true,
   "dependencies": {
+    "electron-settings": "^3.0.14"
+  },
+  "devDependencies": {
+    "@angular/cli": "^1.0.0-beta.32.3",
     "@angular/common": "^2.3.1",
     "@angular/compiler": "^2.3.1",
+    "@angular/compiler-cli": "^2.3.1",
     "@angular/core": "^2.3.1",
     "@angular/forms": "^2.3.1",
     "@angular/http": "^2.3.1",
     "@angular/platform-browser": "^2.3.1",
     "@angular/platform-browser-dynamic": "^2.3.1",
     "@angular/router": "^3.3.1",
-    "angular2-openlayers": "^0.4.5",
-    "core-js": "^2.4.1",
-    "cradle": "^0.7.1",
-    "electron-settings": "^3.0.14",
-    "mustache": "^2.3.0",
-    "pouchdb": "^6.1.1",
-    "rxjs": "^5.0.1",
-    "semver": "^5.3.0",
-    "ts-helpers": "^1.1.1",
-    "zone.js": "^0.7.4"
-  },
-  "devDependencies": {
-    "@angular/cli": "^1.0.0-beta.32.3",
-    "@angular/compiler-cli": "^2.3.1",
     "@types/jasmine": "^2.5.38",
     "@types/node": "^6.0.42",
+    "angular2-openlayers": "^0.4.5",
     "codelyzer": "~2.0.0-beta.1",
+    "core-js": "^2.4.1",
+    "cradle": "^0.7.1",
     "electron": "^1.4.15",
     "electron-builder": "^16.3.0",
     "extract-zip": "1.6.0",
@@ -80,11 +74,16 @@
     "karma-remap-istanbul": "^0.6.0",
     "mustache": "^2.3.0",
     "npm-run-all": "^4.0.1",
+    "pouchdb": "^6.1.1",
     "protractor": "~5.1.1",
     "rimraf": "^2.6.1",
+    "rxjs": "^5.0.1",
+    "semver": "^5.3.0",
+    "ts-helpers": "^1.1.1",
     "ts-node": "^2.1.0",
     "tslint": "^4.3.0",
     "typescript": "~2.2.1",
-    "typescript-formatter": "^5.1.1"
+    "typescript-formatter": "^5.1.1",
+    "zone.js": "^0.7.4"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,11 @@
 
 const {app, BrowserWindow} = require('electron')
 
+// Needs to be loaded here so the renderer process can load it via the
+// remote.require() API.
+// See: https://github.com/nathanbuchar/electron-settings/wiki/FAQs
+const settings = require('electron-settings');
+
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let win


### PR DESCRIPTION
electron-builder will take care of removing devDependencies from the package.

Also include electron-settings in the main process so we can use the remote.require() API to use it in the renderer process.

Fixes #112