### PR TITLE
Make location updates faster in case-list

### DIFF
--- a/src/app/components/case-list/case-list.component.ts
+++ b/src/app/components/case-list/case-list.component.ts
@@ -47,6 +47,7 @@ export class CaseListComponent implements OnInit {
             "$in": this.caseService.filtered_statuses.map(String)
           }
         });
+
       var self = this;
       matchingPromise.then(data => {
 
@@ -63,12 +64,7 @@ export class CaseListComponent implements OnInit {
         var initial_cases_length = this.cases.length;
 
         //loop through cases and load location
-        for (var x = 0; x < initial_cases_length; x++) {
-          if (this.cases[x] && this.cases[x]._id) {
-            var doc = this.cases[x];
-            self.loadLocationForCase(doc._id);
-          }
-        }
+        self.loadLocationForCase();
 
 
       });
@@ -79,11 +75,20 @@ export class CaseListComponent implements OnInit {
 
   }
 
-  loadLocationForCase(case_id: string) {
+  loadLocationForCase() {
     var self = this;
-    self.locationService.getLastLocationMatching(case_id).then(
-      function(loc) {
-        self.caseMeta.locations[case_id] = loc.docs[0];
+    self.locationService.getAllLocations().then(
+      function(locations) {
+        console.log(locations)
+        for (let x = 0; x < self.cases.length; x++) {
+          if (self.cases[x] && self.cases[x]._id) {
+            let doc = self.cases[x];
+            self.caseMeta.locations[doc._id] = locations.rows.filter(function(item) {
+              return item.doc.itemId == doc._id;
+            })[0];
+            console.log(self.caseMeta.locations[doc._id]);
+          }
+        }
       }
     );
   }

--- a/src/app/services/locations.service.ts
+++ b/src/app/services/locations.service.ts
@@ -51,6 +51,10 @@ export class LocationsService {
     );
   }
 
+  getAllLocations() {
+    return this.pouchService.findAll('locations');
+  }
+
   store(location: Location) {
 
     console.log(location);

--- a/src/app/services/pouch.service.ts
+++ b/src/app/services/pouch.service.ts
@@ -191,6 +191,19 @@ export class PouchService {
 
   }
 
+  findAll(db_title: string) {
+    if (this.databases[db_title]['pouchDB']) {
+      console.time('docs');
+      var docs = this.databases[db_title]['pouchDB'].allDocs({
+        include_docs: true,
+        descending: true
+      });
+      console.timeEnd('docs');
+      return docs;
+    }
+    return Promise.reject('No database with name [' + db_title + ']');
+  }
+
   find(db_title: string, selector: any, sort_by = [{ '_id': 'asc' }], limit = 10000) {
     if (this.databases[db_title]['pouchDB']) {
       return Promise.resolve(this.databases[db_title]['pouchDB'].find({


### PR DESCRIPTION
I had a look at the code and there was hidden nested for loop. I resturctred the code a bit and now it is way faster.

I also found this bug report:
https://github.com/nolanlawson/pouchdb-find/issues/207

There it is suggested to just retrieve all documents and filter them in-memory. I also did that, but did not compare it to the previous version after removing the nested loop.