### PR TITLE
empty route removed, because the map is always shown

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -45,10 +45,6 @@ import { SettingsComponent } from './components/settings/settings.component';
     HttpModule,
     RouterModule.forRoot([
       {
-        path: '',
-        component: CaseListComponent
-      },
-      {
         path: 'cases',
         component: CaseListComponent
       }


### PR DESCRIPTION
this caused an underlay of the cases in the map mode.
Now the cases are only shown if the case-list-view is active.